### PR TITLE
manifest: Track our own hardware/broadcom/nfc

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -20,6 +20,7 @@
   <project path="external/unrar" name="LineageOS/android_external_unrar" />
   <project path="external/vim" name="LineageOS/android_external_vim" />
   <project path="external/zip" name="LineageOS/android_external_zip" />
+  <project path="hardware/broadcom/nfc" name="LineageOS/android_hardware_broadcom_nfc" />
   <project path="hardware/lineage/interfaces" name="LineageOS/android_hardware_lineage_interfaces" />
   <project path="hardware/lineage/lineagehw" name="LineageOS/android_hardware_lineage_lineagehw" />
   <!--<project path="hardware/lineage/telephony" name="LineageOS/android_hardware_lineage_telephony" />-->


### PR DESCRIPTION
* Restores the Broadcom NFC HAL from https://github.com/LineageOS/android_system_nfc/commit/11615158154c358029cb2ff10bfb7920bda94e98.

Change-Id: I8aeae70f41f18670783c5655f1ad1cdda1001e25